### PR TITLE
updated code for tfjs-1.0.0

### DIFF
--- a/pix2pix.js
+++ b/pix2pix.js
@@ -15,7 +15,7 @@ class Pix2pix {
   }
 
   async transfer(inputElement, callback = () => {}) {
-    const input = tf.fromPixels(inputElement);
+    const input = tf.browser.fromPixels(inputElement);
     const inputData = input.dataSync();
     const floatInput = tf.tensor3d(inputData, input.shape, 'float32');
     const normalizedInput = tf.div(floatInput, tf.scalar(255));
@@ -31,7 +31,7 @@ class Pix2pix {
     function batchnorm(inputBat, scale, offset) {
       const moments = tf.moments(inputBat, [0, 1]);
       const varianceEpsilon = 1e-5;
-      return tf.batchNormalization(inputBat, moments.mean, moments.variance, varianceEpsilon, scale, offset);
+      return tf.batchNorm(inputBat, moments.mean, moments.variance, offset, scale, varianceEpsilon);
     }
 
     function conv2d(inputCon, filterCon) {


### PR DESCRIPTION
Hey there, Yining.

The [Edges2Pikachu demo](https://yining1023.github.io/pix2pix_tensorflowjs_lite/) wasn't working for me. Updating `tf.fromPixels()` to `tf.browser.fromPixels()` fixed that. (apparently `tf.fromPixels()` was removed in tfjs1.0.0).

I also updated `tf.batchNorm()` (note the new difference in positional arguments) to hide the console's annoying deprecation warning.

Thanks for the awesome stuff.
